### PR TITLE
Update copyright notices

### DIFF
--- a/Source/RedHermesBlueprintNodeEndpoint/Private/RedHermesBlueprintNodeEndpoint.cpp
+++ b/Source/RedHermesBlueprintNodeEndpoint/Private/RedHermesBlueprintNodeEndpoint.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesBlueprintNodeEndpoint.h"
 

--- a/Source/RedHermesBlueprintNodeEndpoint/Public/RedHermesBlueprintNodeEndpoint.h
+++ b/Source/RedHermesBlueprintNodeEndpoint/Public/RedHermesBlueprintNodeEndpoint.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedHermesBlueprintNodeEndpoint/RedHermesBlueprintNodeEndpoint.Build.cs
+++ b/Source/RedHermesBlueprintNodeEndpoint/RedHermesBlueprintNodeEndpoint.Build.cs
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 using UnrealBuildTool;
 

--- a/Source/RedHermesGraphNodeEndpoint/Private/RedHermesGraphNodeEndpoint.cpp
+++ b/Source/RedHermesGraphNodeEndpoint/Private/RedHermesGraphNodeEndpoint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesGraphNodeEndpoint.h"
 

--- a/Source/RedHermesGraphNodeEndpoint/Private/RedHermesGraphNodeEndpointEditorExtension.cpp
+++ b/Source/RedHermesGraphNodeEndpoint/Private/RedHermesGraphNodeEndpointEditorExtension.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesGraphNodeEndpointEditorExtension.h"
 

--- a/Source/RedHermesGraphNodeEndpoint/Private/RedHermesGraphNodeEndpointModule.cpp
+++ b/Source/RedHermesGraphNodeEndpoint/Private/RedHermesGraphNodeEndpointModule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesGraphNodeEndpointModule.h"
 

--- a/Source/RedHermesGraphNodeEndpoint/Private/RedHermesGraphNodeEndpointUtils.cpp
+++ b/Source/RedHermesGraphNodeEndpoint/Private/RedHermesGraphNodeEndpointUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesGraphNodeEndpointUtils.h"
 

--- a/Source/RedHermesGraphNodeEndpoint/Public/RedHermesGraphNodeEndpoint.h
+++ b/Source/RedHermesGraphNodeEndpoint/Public/RedHermesGraphNodeEndpoint.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedHermesGraphNodeEndpoint/Public/RedHermesGraphNodeEndpointEditorExtension.h
+++ b/Source/RedHermesGraphNodeEndpoint/Public/RedHermesGraphNodeEndpointEditorExtension.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedHermesGraphNodeEndpoint/Public/RedHermesGraphNodeEndpointModule.h
+++ b/Source/RedHermesGraphNodeEndpoint/Public/RedHermesGraphNodeEndpointModule.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedHermesGraphNodeEndpoint/Public/RedHermesGraphNodeEndpointUtils.h
+++ b/Source/RedHermesGraphNodeEndpoint/Public/RedHermesGraphNodeEndpointUtils.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedHermesGraphNodeEndpoint/RedHermesGraphNodeEndpoint.Build.cs
+++ b/Source/RedHermesGraphNodeEndpoint/RedHermesGraphNodeEndpoint.Build.cs
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 using UnrealBuildTool;
 

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpoint.cpp
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpoint.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesLevelAtCameraCoordsEndpoint.h"
 

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpointEditorExtension.cpp
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpointEditorExtension.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesLevelAtCameraCoordsEndpointEditorExtension.h"
 

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpointModule.cpp
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpointModule.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesLevelAtCameraCoordsEndpointModule.h"
 

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/Public/RedHermesLevelAtCameraCoordsEndpoint.h
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/Public/RedHermesLevelAtCameraCoordsEndpoint.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/Public/RedHermesLevelAtCameraCoordsEndpointEditorExtension.h
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/Public/RedHermesLevelAtCameraCoordsEndpointEditorExtension.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/Public/RedHermesLevelAtCameraCoordsEndpointModule.h
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/Public/RedHermesLevelAtCameraCoordsEndpointModule.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/RedHermesLevelAtCameraCoordsEndpoint.Build.cs
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/RedHermesLevelAtCameraCoordsEndpoint.Build.cs
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 using UnrealBuildTool;
 

--- a/Source/RedTalaria/Private/RedHermesEndpoint.cpp
+++ b/Source/RedTalaria/Private/RedHermesEndpoint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesEndpoint.h"
 

--- a/Source/RedTalaria/Private/RedTalaria.cpp
+++ b/Source/RedTalaria/Private/RedTalaria.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #include "RedTalaria.h"
 

--- a/Source/RedTalaria/Public/RedHermesEndpoint.h
+++ b/Source/RedTalaria/Public/RedHermesEndpoint.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedTalaria/Public/RedTalaria.h
+++ b/Source/RedTalaria/Public/RedTalaria.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedTalaria/RedTalaria.Build.cs
+++ b/Source/RedTalaria/RedTalaria.Build.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 using UnrealBuildTool;
 

--- a/Source/RedTalariaUrls/Private/RedTalariaGraphNodeUrls.cpp
+++ b/Source/RedTalariaUrls/Private/RedTalariaGraphNodeUrls.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedTalariaGraphNodeUrls.h"
 

--- a/Source/RedTalariaUrls/Private/RedTalariaLevelAtCameraCoordsUrls.cpp
+++ b/Source/RedTalariaUrls/Private/RedTalariaLevelAtCameraCoordsUrls.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #include "RedTalariaLevelAtCameraCoordsUrls.h"
 

--- a/Source/RedTalariaUrls/Private/RedTalariaUrls.cpp
+++ b/Source/RedTalariaUrls/Private/RedTalariaUrls.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedTalariaUrls.h"
 

--- a/Source/RedTalariaUrls/Public/RedTalariaGraphNodeUrls.h
+++ b/Source/RedTalariaUrls/Public/RedTalariaGraphNodeUrls.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedTalariaUrls/Public/RedTalariaLevelAtCameraCoordsUrls.h
+++ b/Source/RedTalariaUrls/Public/RedTalariaLevelAtCameraCoordsUrls.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+﻿// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedTalariaUrls/Public/RedTalariaUrls.h
+++ b/Source/RedTalariaUrls/Public/RedTalariaUrls.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedTalariaUrls/RedTalariaUrls.Build.cs
+++ b/Source/RedTalariaUrls/RedTalariaUrls.Build.cs
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 using UnrealBuildTool;
 


### PR DESCRIPTION
I had some doubts about the "All rights reserved" part, which would imply that the MIT license does not hold. After contacting our legal department, they suggested that we remove the "All rights reserved" phrase completely and leave the copyright part only.