### PR TITLE
Update copyright notices

### DIFF
--- a/Source/RedHermesAutomationEndpoint/Private/RedHermesAutomationEndpoint.cpp
+++ b/Source/RedHermesAutomationEndpoint/Private/RedHermesAutomationEndpoint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedHermesAutomationEndpoint.h"
 

--- a/Source/RedHermesAutomationEndpoint/Public/RedHermesAutomationEndpoint.h
+++ b/Source/RedHermesAutomationEndpoint/Public/RedHermesAutomationEndpoint.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 

--- a/Source/RedTalariaUrls/Private/RedTalariaAutomationUrls.cpp
+++ b/Source/RedTalariaUrls/Private/RedTalariaAutomationUrls.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #include "RedTalariaAutomationUrls.h"
 

--- a/Source/RedTalariaUrls/Public/RedTalariaAutomationUrls.h
+++ b/Source/RedTalariaUrls/Public/RedTalariaAutomationUrls.h
@@ -1,4 +1,4 @@
-// Copyright (c) CD PROJEKT S.A. All Rights Reserved.
+// Copyright (c) CD PROJEKT S.A.
 
 #pragma once
 


### PR DESCRIPTION
I noticed that a couple of newly added files still contain the incorrect copyright notice (as pointed out in #2). This pull request removes the remaining "All Rights Reserved" parts.