### PR TITLE
Add module shortnames to Build.cs files

### DIFF
--- a/Source/RedHermesAutomationEndpoint/RedHermesAutomationEndpoint.Build.cs
+++ b/Source/RedHermesAutomationEndpoint/RedHermesAutomationEndpoint.Build.cs
@@ -6,6 +6,7 @@ public class RedHermesAutomationEndpoint : ModuleRules
 {
 	public RedHermesAutomationEndpoint(ReadOnlyTargetRules Target) : base(Target)
 	{
+		ShortName = "RedHermesAE";
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(

--- a/Source/RedHermesBehaviorTreeNodeEndpoint/RedHermesBehaviorTreeNodeEndpoint.Build.cs
+++ b/Source/RedHermesBehaviorTreeNodeEndpoint/RedHermesBehaviorTreeNodeEndpoint.Build.cs
@@ -6,6 +6,7 @@ public class RedHermesBehaviorTreeNodeEndpoint : ModuleRules
 {
 	public RedHermesBehaviorTreeNodeEndpoint(ReadOnlyTargetRules Target) : base(Target)
 	{
+		ShortName = "RedHermesBTNE";
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(

--- a/Source/RedHermesBlueprintNodeEndpoint/RedHermesBlueprintNodeEndpoint.Build.cs
+++ b/Source/RedHermesBlueprintNodeEndpoint/RedHermesBlueprintNodeEndpoint.Build.cs
@@ -6,6 +6,7 @@ public class RedHermesBlueprintNodeEndpoint : ModuleRules
 {
 	public RedHermesBlueprintNodeEndpoint(ReadOnlyTargetRules Target) : base(Target)
 	{
+		ShortName = "RedHermesBNE";
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(

--- a/Source/RedHermesContentFolderEndpoint/RedHermesContentFolderEndpoint.Build.cs
+++ b/Source/RedHermesContentFolderEndpoint/RedHermesContentFolderEndpoint.Build.cs
@@ -6,6 +6,7 @@ public class RedHermesContentFolderEndpoint : ModuleRules
 {
 	public RedHermesContentFolderEndpoint(ReadOnlyTargetRules Target) : base(Target)
 	{
+		ShortName = "RedHermesCFE";
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(

--- a/Source/RedHermesGraphNodeEndpoint/RedHermesGraphNodeEndpoint.Build.cs
+++ b/Source/RedHermesGraphNodeEndpoint/RedHermesGraphNodeEndpoint.Build.cs
@@ -6,6 +6,7 @@ public class RedHermesGraphNodeEndpoint : ModuleRules
 {
 	public RedHermesGraphNodeEndpoint(ReadOnlyTargetRules Target) : base(Target)
 	{
+		ShortName = "RedHermesGNE";
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(

--- a/Source/RedHermesLevelActorEndpoint/RedHermesLevelActorEndpoint.Build.cs
+++ b/Source/RedHermesLevelActorEndpoint/RedHermesLevelActorEndpoint.Build.cs
@@ -6,6 +6,7 @@ public class RedHermesLevelActorEndpoint : ModuleRules
 {
 	public RedHermesLevelActorEndpoint(ReadOnlyTargetRules Target) : base(Target)
 	{
+		ShortName = "RedHermesLAE";
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/RedHermesLevelAtCameraCoordsEndpoint.Build.cs
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/RedHermesLevelAtCameraCoordsEndpoint.Build.cs
@@ -6,6 +6,7 @@ public class RedHermesLevelAtCameraCoordsEndpoint : ModuleRules
 {
 	public RedHermesLevelAtCameraCoordsEndpoint(ReadOnlyTargetRules Target) : base(Target)
 	{
+		ShortName = "RedHermesLACCE";
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(


### PR DESCRIPTION
Since these module names are kind of long (and nested inside of `Project/Plugins/RedTalaria`), these can cause you to get warnings from UBT (or errors from cl.exe) due to the max path length. This helps remedy that by using shortnames for all the longer module names.