### PR TITLE
Adapt the linking levels at a specific camera position command to the new level viewport toolbar

### DIFF
--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpointEditorExtension.cpp
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpointEditorExtension.cpp
@@ -7,6 +7,7 @@
 #include "RedTalaria.h"
 #include "RedTalariaLevelAtCameraCoordsUrls.h"
 #include "ToolMenus.h"
+#include "Misc/EngineVersionComparison.h"
 #include "HAL/PlatformApplicationMisc.h"
 
 #define LOCTEXT_NAMESPACE "Editor.RedHermesLevelAtCameraCoordsEndpointEditorExtension"
@@ -25,7 +26,15 @@ void URedHermesLevelAtCameraCoordsEndpointEditorExtension::RegisterViewportOptio
 {
 	FToolMenuOwnerScoped ToolMenuOwnerScoped(this);
 
-	if (UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelViewportToolBar.Options"))
+#if UE_VERSION_OLDER_THAN(5,6,0)
+	static const FName ViewportMenuName("LevelEditor.LevelViewportToolBar.Options");
+	static const FName ViewportMenuFirstSection("LevelViewportViewportOptions");
+#else
+	static const FName ViewportMenuName("LevelEditor.LevelViewportToolBar.Camera");
+	static const FName ViewportMenuFirstSection("LevelViewportCameraType_Perspective");
+#endif
+
+	if (UToolMenu* Menu = UToolMenus::Get()->ExtendMenu(ViewportMenuName))
 	{
 		static auto GetPerspectiveLevelEditorViewportClient = [](const FToolMenuContext& MenuContext) -> FLevelEditorViewportClient* {
 			ULevelViewportToolBarContext* Context = MenuContext.FindContext<ULevelViewportToolBarContext>();
@@ -58,8 +67,8 @@ void URedHermesLevelAtCameraCoordsEndpointEditorExtension::RegisterViewportOptio
 
 		FToolMenuSection& Section = Menu->AddSection(
 			TEXT("Hermes"),
-			LOCTEXT("LevelViewportToolBar.Options.Hermes", "Hermes"),
-			FToolMenuInsert(TEXT("LevelViewportViewportOptions"), EToolMenuInsertType::Before));
+			LOCTEXT("LevelViewportToolBar.Section.Hermes", "Hermes"),
+			FToolMenuInsert(ViewportMenuFirstSection, EToolMenuInsertType::Before));
 		Section.AddMenuEntry("CopyURL",
 			LOCTEXT("ViewportAction.CopyCameraCoordsUrl", "Copy camera coords URL"),
 			LOCTEXT("ViewportAction.CopyCameraCoordsUrlTooltip", "Copy an URL that will open this level at the current camera position"),

--- a/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpointEditorExtension.cpp
+++ b/Source/RedHermesLevelAtCameraCoordsEndpoint/Private/RedHermesLevelAtCameraCoordsEndpointEditorExtension.cpp
@@ -37,8 +37,12 @@ void URedHermesLevelAtCameraCoordsEndpointEditorExtension::RegisterViewportOptio
 	if (UToolMenu* Menu = UToolMenus::Get()->ExtendMenu(ViewportMenuName))
 	{
 		static auto GetPerspectiveLevelEditorViewportClient = [](const FToolMenuContext& MenuContext) -> FLevelEditorViewportClient* {
-			ULevelViewportToolBarContext* Context = MenuContext.FindContext<ULevelViewportToolBarContext>();
-			if (Context && Context->LevelViewportToolBarWidget.IsValid())
+#if UE_VERSION_OLDER_THAN(5,7,0)
+			if (ULevelViewportToolBarContext* Context = MenuContext.FindContext<ULevelViewportToolBarContext>();
+				Context && Context->LevelViewportToolBarWidget.IsValid())
+#else
+			if (ULevelViewportContext* Context = MenuContext.FindContext<ULevelViewportContext>())
+#endif
 			{
 				FLevelEditorViewportClient* ViewportClient = Context->GetLevelViewportClient();
 				if (ViewportClient && ViewportClient->ViewportType == LVT_Perspective)


### PR DESCRIPTION
With the new toolbar, the "Copy camera cords URL" command is available under the Camera menu in the viewport.
The old Option menu is no longer available in the new level viewport toolbar.

Tested with engines: 5.5.4, 5.6.1, and 5.7.4.

<img width="273" height="96" alt="image" src="https://github.com/user-attachments/assets/7c2144c1-fc7f-4c47-8078-39a42737b7c8" />
<img width="1255" height="448" alt="image" src="https://github.com/user-attachments/assets/cdac3719-fe5f-43b1-a9ab-6df7272f9a18" />
